### PR TITLE
Fix MessageContent serialization on creation of new MessageEnvelope.

### DIFF
--- a/src/SimpleMessageBus.Core/MessageEnvelope.cs
+++ b/src/SimpleMessageBus.Core/MessageEnvelope.cs
@@ -75,7 +75,7 @@ namespace CloudNimble.SimpleMessageBus.Core
             }
 
             MessageType = message.GetType().SimpleAssemblyQualifiedName();
-            MessageContent = JsonSerializer.Serialize(message);
+            MessageContent = JsonSerializer.Serialize(message, message.GetType());
         }
 
         #endregion

--- a/src/SimpleMessageBus.Tests.Core/MessageEnvelopTests.cs
+++ b/src/SimpleMessageBus.Tests.Core/MessageEnvelopTests.cs
@@ -1,0 +1,30 @@
+using CloudNimble.SimpleMessageBus.Core;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SimpleMessageBus.Tests.Shared;
+
+namespace SimpleMessageBus.Tests.Core
+{
+    [TestClass]
+    public class MessageEnvelopTests
+    {
+        [TestMethod]
+        public void MessageEnvelop_SerializesMessageContent()
+        {
+            var testMessage = new TestMessage
+            {
+                Greeting = "Hello world!",
+                PickANumber = 42,
+                BirthDay = new System.DateTime(1970, 4, 14)
+            };
+            testMessage.Id.Should().NotBeEmpty();
+
+            var envelope = new MessageEnvelope(testMessage);
+
+            envelope.MessageContent.Should().NotBeNullOrEmpty();
+            envelope.MessageContent.Should().ContainAll(testMessage.Id.ToString(), testMessage.Greeting, testMessage.PickANumber.ToString(), testMessage.BirthDay.ToString("yyyy-MM-dd"));
+            envelope.MessageType.Should().Contain(testMessage.GetType().FullName);
+        }
+
+    }
+}

--- a/src/SimpleMessageBus.Tests.Core/SimpleMessageBus.Tests.Core.csproj
+++ b/src/SimpleMessageBus.Tests.Core/SimpleMessageBus.Tests.Core.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SimpleMessageBus.Core\SimpleMessageBus.Core.csproj" />
+    <ProjectReference Include="..\SimpleMessageBus.Tests.Shared\SimpleMessageBus.Tests.Shared.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SimpleMessageBus.Tests.Shared/TestMessage.cs
+++ b/src/SimpleMessageBus.Tests.Shared/TestMessage.cs
@@ -5,21 +5,38 @@ namespace SimpleMessageBus.Tests.Shared
 {
 
     /// <summary>
-    /// 
+    /// A test message for the publishers / dispatchers.
     /// </summary>
     public class TestMessage : IMessage
     {
 
         /// <summary>
-        /// 
+        /// Message identifier.
         /// </summary>
         public Guid Id { get; set; }
 
+        /// <summary>
+        /// Default constructor that sets a unique value for the identifier.
+        /// </summary>
         public TestMessage()
         {
             Id = Guid.NewGuid();
         }
 
-    }
+        /// <summary>
+        /// String value to test that all properties are being serialized correctly.
+        /// </summary>
+        public string Greeting { get; set; }
 
+        /// <summary>
+        /// Integer value to test that all properties are being serialized correctly.
+        /// </summary>
+        public int PickANumber { get; set; }
+
+        /// <summary>
+        /// DateTime value to test that all properties are being serialized correctly.
+        /// </summary>
+        public DateTime BirthDay { get; set; }
+
+    }
 }


### PR DESCRIPTION
System.Text serialization on IMessage was losing fields defined in derived types.  This fix uses the inputType parameter on the serializer to ensure that all fields in the message are properly serialized.